### PR TITLE
add lvds support and new pll module ports

### DIFF
--- a/colorBarDVI/Makefile
+++ b/colorBarDVI/Makefile
@@ -15,17 +15,17 @@ CONSTR = $(TOP).ccf
 OBJS += $(TOP).v
 OBJS += ../libs/graphics/color_bar_shade.v
 OBJS += ../libs/clocks/gatemate_25MHz_125MHz_pll.v
-OBJS += ../libs//graphics/vga_core.v
-OBJS += ../libs//graphics/dvi_core.v
-OBJS += ../libs//graphics/tmds_encoder.v
-OBJS += ../libs//ios/serializer_gatemate_10_to_1_generic_ddr.v
+OBJS += ../libs/graphics/vga_core.v
+OBJS += ../libs/graphics/dvi_core.v
+OBJS += ../libs/graphics/tmds_encoder.v
+OBJS += ../libs/ios/serializer_gatemate_10_to_1_generic_ddr.v
 
 YS_OPTS = -D DISP_640x480_60Hz=1
 
 all:impl
 synth: $(TOP)_synth.v
 $(TOP)_synth.v: $(OBJS)
-	$(YOSYS) -ql synth.log $(YS_OPTS) -p 'read -sv $^; synth_gatemate -top $(TOP) -nomx8 -vlog $(TOP)_synth.v'
+	$(YOSYS) -ql synth.log $(YS_OPTS) -p 'read_verilog -sv $^; synth_gatemate -top $(TOP) -nomx8 -vlog $(TOP)_synth.v'
 
 $(TOP)_00.cfg: $(TOP)_synth.v $(CONSTR)
 	$(P_R) -i $(TOP)_synth.v -ccf $(CONSTR) -o $(TOP) $(PRFLAGS) > $@.log

--- a/colorBarDVI/colorBarDVI.ccf
+++ b/colorBarDVI/colorBarDVI.ccf
@@ -1,12 +1,11 @@
 Pin_in  "clk_i"  Loc = "IO_SB_A8" | SCHMITT_TRIGGER=true;
-Pin_in  "rstn_i" Loc = "IO_EB_B0" | PULLUP=true; # SW3
 
 #J1
-Pin_out "TMDS_0_data_n[2]" Loc = "IO_NB_A0"; #JA1
-Pin_out "TMDS_0_data_n[1]" Loc = "IO_NB_A1"; #JA2
-Pin_out "TMDS_0_data_n[0]" Loc = "IO_NB_A2"; #JA3
-Pin_out "TMDS_0_clk_n"     Loc = "IO_NB_A3"; #JA4
-Pin_out "TMDS_0_data_p[2]" Loc = "IO_NB_B0"; #JA7
-Pin_out "TMDS_0_data_p[1]" Loc = "IO_NB_B1"; #JA8
-Pin_out "TMDS_0_data_p[0]" Loc = "IO_NB_B2"; #JA9
-Pin_out "TMDS_0_clk_p"     Loc = "IO_NB_B3"; #JA10
+Pin_out "TMDS_0_data_n[2]" Loc = "IO_NB_A0" | LVDS_BOOST=true; #JA1
+Pin_out "TMDS_0_data_n[1]" Loc = "IO_NB_A1" | LVDS_BOOST=true; #JA2
+Pin_out "TMDS_0_data_n[0]" Loc = "IO_NB_A2" | LVDS_BOOST=true; #JA3
+Pin_out "TMDS_0_clk_n"     Loc = "IO_NB_A3" | LVDS_BOOST=true; #JA4
+Pin_out "TMDS_0_data_p[2]" Loc = "IO_NB_B0" | LVDS_BOOST=true; #JA7
+Pin_out "TMDS_0_data_p[1]" Loc = "IO_NB_B1" | LVDS_BOOST=true; #JA8
+Pin_out "TMDS_0_data_p[0]" Loc = "IO_NB_B2" | LVDS_BOOST=true; #JA9
+Pin_out "TMDS_0_clk_p"     Loc = "IO_NB_B3" | LVDS_BOOST=true; #JA10


### PR DESCRIPTION
This PR matches to https://github.com/trabucayre/fpgalibs/pull/1.

TMDS signals are differential pairs using `CC_LVDS_OBUF` instances to reduce internal overhead.

Tested with latest toolchain binaries.